### PR TITLE
Add GHCR permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,9 +7,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Build Docker image
-        run: docker build . -t openproject_export:test
+        run: |
+          docker build . \
+            -t openproject_export:test \
+            -t ghcr.io/${{ github.repository_owner }}/openproject_export:latest
       - name: Test Docker image
         run: docker run --rm openproject_export:test git --version
+      - name: Push image
+        run: docker push ghcr.io/${{ github.repository_owner }}/openproject_export:latest


### PR DESCRIPTION
## Summary
- grant write package permissions when pushing to GHCR

## Testing
- `docker build . -t openproject_export:test` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68689e5b8f248322843b4137ab52d799