### PR TITLE
Update plugin handling for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM openproject/openproject:16 AS plugin
 # COPY /path/to/my/local/openproject-slack /app/vendor/plugins/openproject-slack
 
 COPY Gemfile.plugins /app/
+COPY openproject-export /app/plugins/openproject-export
 
 # If the plugin uses any external NPM dependencies you have to install them here.
 # RUN npm add npm <package-name>*

--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,3 +1,3 @@
 group :opf_plugins do
-  gem "openproject-slack", git: "https://github.com/opf/openproject-slack.git", branch: "dev"
+  gem 'openproject-export', path: '/app/plugins/openproject-export'
 end


### PR DESCRIPTION
## Summary
- copy `openproject-export` plugin into Docker image
- configure `Gemfile.plugins` to use local plugin path
- remove `openproject-slack` reference

## Testing
- `bundle check` *(fails: missing gems)*
- `bundle install` *(fails: bundler error)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6868a4a366bc832294c1a7cb5c0e8b34