### PR TITLE
Update plugin handling for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,14 @@ FROM openproject/openproject:16 AS plugin
 # COPY /path/to/my/local/openproject-slack /app/vendor/plugins/openproject-slack
 
 COPY Gemfile.plugins /app/
+COPY openproject-export /app/vendor/plugins/openproject-export
 
 # If the plugin uses any external NPM dependencies you have to install them here.
 # RUN npm add npm <package-name>*
 
-RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
+RUN bundle config unset deployment
+RUN bundle install
+RUN bundle config set deployment 'true'
 RUN ./docker/prod/setup/precompile-assets.sh
 
 FROM openproject/openproject:16-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM openproject/openproject:16 AS plugin
 # COPY /path/to/my/local/openproject-slack /app/vendor/plugins/openproject-slack
 
 COPY Gemfile.plugins /app/
-COPY openproject-export /app/vendor/plugins/openproject-export
+COPY openproject-export /app/plugins/openproject-export
 
 # If the plugin uses any external NPM dependencies you have to install them here.
 # RUN npm add npm <package-name>*

--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,3 +1,3 @@
 group :opf_plugins do
-  gem 'openproject-export', path: '/app/vendor/plugins/openproject-export'
+  gem 'openproject-export', path: '/app/plugins/openproject-export'
 end

--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,3 +1,3 @@
 group :opf_plugins do
-  gem "openproject-slack", git: "https://github.com/opf/openproject-slack.git", branch: "dev"
+  gem 'openproject-export', path: '/app/vendor/plugins/openproject-export'
 end


### PR DESCRIPTION
## Summary
- copy `openproject-export` plugin into `/app/vendor/plugins/openproject-export`
- update `Gemfile.plugins` to match new plugin path

## Testing
- `bundle check` *(fails: uninitialized constant DidYouMean::SPELL_CHECKERS)*

------
https://chatgpt.com/codex/tasks/task_e_6868a4a366bc832294c1a7cb5c0e8b34