### PR TITLE
Fix merge conflict in export.rb

### DIFF
--- a/openproject-export/lib/open_project/export.rb
+++ b/openproject-export/lib/open_project/export.rb
@@ -1,5 +1,6 @@
 module OpenProject
   module Export
     require "open_project/export/engine"
+    require "open_project/export/hooks"
   end
 end

--- a/openproject-export/lib/open_project/export/hooks.rb
+++ b/openproject-export/lib/open_project/export/hooks.rb
@@ -1,5 +1,6 @@
 module OpenProject
   module Export
+    require 'open_project/hook'
     class Hooks < OpenProject::Hook::ViewListener
       render_on :view_projects_settings_menu,
                 partial: 'open_project/export/hooks/download_all_button'


### PR DESCRIPTION
## Summary
- resolve leftover conflict by requiring hooks in `export.rb`
- ensure Hooks class loads OpenProject hook framework

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68698b5c3c6c832297c8590ff2449709