### PR TITLE
Fix Redmine dependency for hooks

### DIFF
--- a/openproject-export/lib/open_project/export.rb
+++ b/openproject-export/lib/open_project/export.rb
@@ -1,5 +1,6 @@
 module OpenProject
   module Export
     require "open_project/export/engine"
+    require "open_project/export/hooks"
   end
 end

--- a/openproject-export/lib/open_project/export/hooks.rb
+++ b/openproject-export/lib/open_project/export/hooks.rb
@@ -1,5 +1,7 @@
 module OpenProject
   module Export
+    require 'redmine/i18n'
+    require 'open_project/hook'
     class Hooks < OpenProject::Hook::ViewListener
       render_on :view_projects_settings_menu,
                 partial: 'open_project/export/hooks/download_all_button'


### PR DESCRIPTION
## Summary
- require `redmine/i18n` before `open_project/hook` to ensure the hook system can load

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68698b5c3c6c832297c8590ff2449709