### PR TITLE
Fix Redmine hooks conflict

### DIFF
--- a/openproject-export/lib/open_project/export.rb
+++ b/openproject-export/lib/open_project/export.rb
@@ -1,5 +1,8 @@
 module OpenProject
   module Export
     require "open_project/export/engine"
+    require 'redmine/i18n'
+    require 'open_project/hook'
+    require "open_project/export/hooks"
   end
 end


### PR DESCRIPTION
## Summary
- make sure Redmine I18n and the OpenProject hook system load before the hooks file
- clean up hooks.rb since dependencies are now loaded in export.rb

## Testing
- `bundle install --local || bundle install`
- `bundle exec rake spec` *(fails: No Rakefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68698b5c3c6c832297c8590ff2449709