### PR TITLE
Fix plugin loading without OpenProject core

### DIFF
--- a/openproject-export/lib/open_project/export.rb
+++ b/openproject-export/lib/open_project/export.rb
@@ -1,6 +1,10 @@
 module OpenProject
   module Export
     require "open_project/export/engine"
-    require "open_project/export/hooks"
+    begin
+      require "open_project/export/hooks"
+    rescue LoadError
+      warn "OpenProject::Export::Hooks could not be loaded"
+    end
   end
 end

--- a/openproject-export/lib/open_project/export/engine.rb
+++ b/openproject-export/lib/open_project/export/engine.rb
@@ -13,7 +13,11 @@ module OpenProject
                requires_openproject: '>= 13.1.0'
 
       initializer 'openproject-export.register_hooks' do
-        ::OpenProject::Export::Hooks
+        begin
+          ::OpenProject::Export::Hooks
+        rescue NameError
+          # Hooks not loaded (missing OpenProject core)
+        end
       end
     end
   end

--- a/openproject-export/lib/open_project/export/hooks.rb
+++ b/openproject-export/lib/open_project/export/hooks.rb
@@ -1,6 +1,17 @@
 module OpenProject
   module Export
-    require 'open_project/hook'
+    require 'redmine/i18n'
+    begin
+      require 'open_project/hook'
+    rescue LoadError
+      module ::OpenProject
+        module Hook
+          class ViewListener
+            def self.render_on(*); end
+          end
+        end
+      end
+    end
     class Hooks < OpenProject::Hook::ViewListener
       render_on :view_projects_settings_menu,
                 partial: 'open_project/export/hooks/download_all_button'

--- a/openproject-export/lib/redmine/i18n.rb
+++ b/openproject-export/lib/redmine/i18n.rb
@@ -1,0 +1,8 @@
+module Redmine
+  module I18n
+
+    def self.included(base)
+      base.extend self
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- avoid load errors if OpenProject core is not present
- add minimal Redmine::I18n stub
- guard hook registration

## Testing
- `bundle exec rake spec`

------
https://chatgpt.com/codex/tasks/task_e_686999235d7c8322b71cafb490d8596a