### PR TITLE
Add Backup Project button

### DIFF
--- a/openproject-export/README.md
+++ b/openproject-export/README.md
@@ -2,6 +2,7 @@
 
 This plugin adds a button to the project settings sidebar allowing you to download all attachments of the active project as a ZIP archive.
 
+This plugin also adds a "Backup Project" button to create a zipped backup of the project.
 ## Usage
 
 Add the plugin to `Gemfile.plugins` of your OpenProject installation:
@@ -13,3 +14,4 @@ end
 ```
 
 After adding it, run `./bin/setup_dev` from your OpenProject core directory and start the server normally.
+

--- a/openproject-export/app/controllers/open_project/export/backups_controller.rb
+++ b/openproject-export/app/controllers/open_project/export/backups_controller.rb
@@ -1,0 +1,34 @@
+require 'zip'
+
+module OpenProject
+  module Export
+    class BackupsController < ::ApplicationController
+      before_action :find_project, :authorize
+
+      def download
+        send_data zipped_project,
+                  type: 'application/zip',
+                  filename: "#{@project.identifier}-backup.zip"
+      end
+
+      private
+
+      def find_project
+        @project = Project.find(params[:project_id])
+      end
+
+      def zipped_project
+        buffer = Zip::OutputStream.write_buffer do |zip|
+          @project.attachments.each do |attachment|
+            next unless attachment.file.present?
+            zip.put_next_entry(attachment.filename)
+            zip.write attachment.diskfile.binread
+          end
+        end
+        buffer.rewind
+        buffer.read
+      end
+    end
+  end
+end
+

--- a/openproject-export/app/views/open_project/export/hooks/_backup_button.html.erb
+++ b/openproject-export/app/views/open_project/export/hooks/_backup_button.html.erb
@@ -1,0 +1,4 @@
+<%= link_to t(:backup_project_name),
+            backup_project_path(@project),
+            class: 'button -with-icon icon-download' %>
+

--- a/openproject-export/config/locales/en.yml
+++ b/openproject-export/config/locales/en.yml
@@ -1,2 +1,5 @@
 en:
   attachment_export_name: Attachment export
+
+  backup_project_name: Backup Project
+

--- a/openproject-export/config/locales/js-en.yml
+++ b/openproject-export/config/locales/js-en.yml
@@ -1,3 +1,6 @@
 en:
   js:
     attachment_export_name: 'Attachment export'
+
+    backup_project_name: "Backup Project"
+

--- a/openproject-export/config/routes.rb
+++ b/openproject-export/config/routes.rb
@@ -2,4 +2,8 @@ OpenProject::Export::Engine.routes.draw do
   get '/projects/:project_id/attachments/download_all',
       to: 'attachments#download_all',
       as: 'download_all_project_attachments'
+  get "/projects/:project_id/backup",
+      to: "backups#download",
+      as: "backup_project"
 end
+

--- a/openproject-export/lib/open_project/export/hooks.rb
+++ b/openproject-export/lib/open_project/export/hooks.rb
@@ -15,6 +15,9 @@ module OpenProject
     class Hooks < OpenProject::Hook::ViewListener
       render_on :view_projects_settings_menu,
                 partial: 'open_project/export/hooks/download_all_button'
+      render_on :view_projects_settings_menu,
+                partial: "open_project/export/hooks/backup_button"
     end
   end
 end
+


### PR DESCRIPTION
## Summary
- add a BackupsController and endpoint for project backups
- expose a Backup Project button in the settings menu
- localize text for the new button
- mention the backup feature in the README

## Testing
- `bundle exec rake spec` *(fails: cannot load such file -- rspec/core/rake_task)*

------
https://chatgpt.com/codex/tasks/task_e_686a85edc75c8322b4930d16ee4664f0