### PR TITLE
Fix backup menu entry

### DIFF
--- a/openproject-export/app/views/open_project/export/hooks/_backup_button.html.erb
+++ b/openproject-export/app/views/open_project/export/hooks/_backup_button.html.erb
@@ -1,4 +1,0 @@
-<li>
-  <%= link_to t(:backup_project_name),
-              backup_project_path(@project) %>
-</li>

--- a/openproject-export/lib/open_project/export/engine.rb
+++ b/openproject-export/lib/open_project/export/engine.rb
@@ -16,11 +16,19 @@ module OpenProject
                      { 'open_project/export/backups' => [:download] },
                      permissible_on: [:project]
         end
+
+        menu :project_menu,
+             :backup_project,
+             { controller: '/open_project/export/backups', action: :download },
+             if: ->(project) {
+               project.module_enabled?(:export_backups) &&
+                 User.current.allowed_to?(:download_project_backup, project)
+             },
+             caption: :backup_project_name,
+             parent: :settings,
+             icon: 'download'
       end
 
-      config.to_prepare do
-        require_dependency 'open_project/export/hooks'
-      end
     end
   end
 end

--- a/openproject-export/lib/open_project/export/hooks.rb
+++ b/openproject-export/lib/open_project/export/hooks.rb
@@ -1,9 +1,0 @@
-module OpenProject
-  module Export
-    class Hooks < OpenProject::Hook::ViewListener
-      render_on :view_projects_settings_menu,
-                partial: 'open_project/export/hooks/backup_button'
-    end
-  end
-end
-


### PR DESCRIPTION
## Summary
- register a menu item directly instead of using hooks
- remove old hook code and view partial

## Testing
- `bundle exec rake spec` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_686b1aea020083229dc398530b1257d6